### PR TITLE
feat: simplify validator signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Check out the schema [documentation](https://qualipool.github.io/swissrets-json/
 
 ```ts
 import {
-    validateSwissRetsString,
-    validateSwissRetsObject,
+    validateSwissRets,
     SwissRetsInventory
 } from '@qualipool/swissrets-json';
 
@@ -31,7 +30,7 @@ const stringValue = `{
     },
     "properties": []
     }`;
-const result = validateSwissRetsString(stringValue);
+const result = validateSwissRets(Value);
 console.log(result);
 
 // validating a SwissRETS JSON object
@@ -44,6 +43,6 @@ const srObject: SwissRetsInventory = {
     properties: []
 };
 
-result = validateSwissRetsObject(srObject);
+result = validateSwissRets(srObject);
 console.log(result);
 ```

--- a/examples/swissrets-full.json
+++ b/examples/swissrets-full.json
@@ -2,7 +2,7 @@
   "created": "2023-03-23T08:11:12Z",
   "generator": {
     "name": "CASAGATEWAY",
-    "version": "2.7"
+    "version": "3.0"
   },
   "properties": [
     {

--- a/examples/swissrets-min.json
+++ b/examples/swissrets-min.json
@@ -2,7 +2,7 @@
   "created": "2023-03-23T08:11:12Z",
   "generator": {
     "name": "CASAGATEWAY",
-    "version": "0.9"
+    "version": "3.0"
   },
   "properties": [
     {

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,5 +1,8 @@
 export * from './model/swissrets-model';
-export { validateSwissRetsObject, validateSwissRetsString } from './validator/validator';
+export {
+  validateSwissRets as validateSwissRetsString,
+  validateSwissRets as validateSwissRetsString
+} from './validator/validator';
 export * from './validator/validator-types';
 // eslint-disable-next-line prettier/prettier
 

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,8 +1,5 @@
 export * from './model/swissrets-model';
-export {
-  validateSwissRets as validateSwissRetsString,
-  validateSwissRets as validateSwissRetsString
-} from './validator/validator';
+export { validateSwissRets } from './validator/validator';
 export * from './validator/validator-types';
 // eslint-disable-next-line prettier/prettier
 

--- a/src/ts/tests/created/test.spec.ts
+++ b/src/ts/tests/created/test.spec.ts
@@ -2,12 +2,12 @@ import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('created tests', () => {
   it('Invalid - must be string', () => {
     const invalid = stubSrFullModified('created', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/created');
@@ -15,7 +15,7 @@ describe('created tests', () => {
 
   it('Invalid - not valid string', () => {
     const invalid = stubSrFullModified('created', () => '');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have fewer than 1 characters');
     expect(output[0].instancePath).toBe('/created');
@@ -26,7 +26,7 @@ describe('created tests', () => {
   it('Valid - created is optional', () => {
     const valid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(valid, 'created');
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/generator/test.spec.ts
+++ b/src/ts/tests/generator/test.spec.ts
@@ -2,12 +2,12 @@ import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('generator tests', () => {
   it('Invalid - generator has invalid type', () => {
     const invalid = stubSrFullModified('generator', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/generator');
@@ -16,7 +16,7 @@ describe('generator tests', () => {
   it('Invalid - generator has additional property', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.generator, { additionalProp: 33 });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/generator');
@@ -24,7 +24,7 @@ describe('generator tests', () => {
 
   it('Invalid - generator.name has invalid type', () => {
     const invalid = stubSrFullModified('generator.name', () => 44);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/generator/name');
@@ -32,7 +32,7 @@ describe('generator tests', () => {
 
   it('Invalid - generator.name must NOT have fewer than 1 characters', () => {
     const invalid = stubSrFullModified('generator.name', () => '');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have fewer than 1 characters');
     expect(output[0].instancePath).toBe('/generator/name');
@@ -40,7 +40,7 @@ describe('generator tests', () => {
 
   it('Invalid - generator.version must be string', () => {
     const invalid = stubSrFullModified('generator.version', () => 88);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/generator/version');
@@ -48,7 +48,7 @@ describe('generator tests', () => {
 
   it('Invalid - generator.version must NOT have fewer than 1 characters', () => {
     const invalid = stubSrFullModified('generator.version', () => '');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have fewer than 1 characters');
     expect(output[0].instancePath).toBe('/generator/version');
@@ -57,7 +57,7 @@ describe('generator tests', () => {
   it("Invalid - generator.version must have required property 'version'", () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'generator.version');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'version'");
     expect(output[0].instancePath).toBe('/generator');

--- a/src/ts/tests/projects/project/address/geo/test.spec.ts
+++ b/src/ts/tests/projects/project/address/geo/test.spec.ts
@@ -2,13 +2,13 @@ import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFull, stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('projects[0].address.geo tests', () => {
   it('Invalid - projects[0].address.geo cannot have additional properties', () => {
     const invalid = stubSrFull();
     _.assign(invalid.projects![0]!.address!.geo, { additionalProperty: 'additionalProperty' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/address/geo');
@@ -16,7 +16,7 @@ describe('projects[0].address.geo tests', () => {
 
   it('Invalid - projects[0].address.geo must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].address.geo', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/address/geo');
@@ -25,7 +25,7 @@ describe('projects[0].address.geo tests', () => {
   it('Valid - projects[0].address.geo.elevation can be omitted', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].address.geo.elevation');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -33,7 +33,7 @@ describe('projects[0].address.geo tests', () => {
 
   it('Invalid - projects[0].address.geo.elevation must be of type number', () => {
     const invalid = stubSrFullModified('projects[0].address.geo.elevation', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be number');
     expect(output[0].instancePath).toBe('/projects/0/address/geo/elevation');
@@ -42,7 +42,7 @@ describe('projects[0].address.geo tests', () => {
   it('Invalid - projects[0].address.geo.latitude must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].address.geo.latitude');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'latitude'");
     expect(output[0].instancePath).toBe('/projects/0/address/geo');
@@ -50,7 +50,7 @@ describe('projects[0].address.geo tests', () => {
 
   it('Invalid - projects[0].address.geo.latitude must be of type number', () => {
     const invalid = stubSrFullModified('projects[0].address.geo.latitude', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be number');
     expect(output[0].instancePath).toBe('/projects/0/address/geo/latitude');
@@ -59,7 +59,7 @@ describe('projects[0].address.geo tests', () => {
   it('Invalid - projects[0].address.geo.longitude must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].address.geo.longitude');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'longitude'");
     expect(output[0].instancePath).toBe('/projects/0/address/geo');
@@ -67,7 +67,7 @@ describe('projects[0].address.geo tests', () => {
 
   it('Invalid - projects[0].address.geo.longitude must be of type number', () => {
     const invalid = stubSrFullModified('projects[0].address.geo.longitude', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be number');
     expect(output[0].instancePath).toBe('/projects/0/address/geo/longitude');

--- a/src/ts/tests/projects/project/address/test.spec.ts
+++ b/src/ts/tests/projects/project/address/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('projects[0].address tests', () => {
   it('Valid - projects[0].address can be an empty object', () => {
     const invalid = stubSrFullModified('projects[0].address', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -17,7 +17,7 @@ describe('projects[0].address tests', () => {
   it('Invalid - projects[0].address cannot have additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.projects![0].address, { additionalProperty: 'additionalProperty' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/address');
@@ -25,7 +25,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].address', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/address');
@@ -33,7 +33,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.countryCode must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].address.countryCode', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/address/countryCode');
@@ -41,7 +41,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.countryCode must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].address.countryCode', () => 'fff.fff');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "[A-Z]{2}"');
     expect(output[0].instancePath).toBe('/projects/0/address/countryCode');
@@ -49,7 +49,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.locality must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].address.locality', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/address/locality');
@@ -57,7 +57,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.region must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].address.region', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/address/region');
@@ -65,7 +65,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.postalCode must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].address.postalCode', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/address/postalCode');
@@ -73,7 +73,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.postOfficeBoxNumber must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].address.postOfficeBoxNumber', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/address/postOfficeBoxNumber');
@@ -81,7 +81,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.street must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].address.street', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/address/street');
@@ -89,7 +89,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.streetNumber must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].address.streetNumber', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/address/streetNumber');
@@ -97,7 +97,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.streetAddition must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].address.streetAddition', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/address/streetAddition');
@@ -105,7 +105,7 @@ describe('projects[0].address tests', () => {
 
   it('Invalid - projects[0].address.subunit must be of type integer', () => {
     const invalid = stubSrFullModified('projects[0].address.subunit', () => 'a');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be integer');
     expect(output[0].instancePath).toBe('/projects/0/address/subunit');

--- a/src/ts/tests/projects/project/availability/test.spec.ts
+++ b/src/ts/tests/projects/project/availability/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('projects[0].availability tests', () => {
   it('Invalid - projects[0].availability has invalid type', () => {
     const invalid = stubSrFullModified('projects[0].availability', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/availability');
@@ -17,7 +17,7 @@ describe('projects[0].availability tests', () => {
   it('Invalid - projects[0].availability has additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.projects![0].availability, { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/availability');
@@ -25,7 +25,7 @@ describe('projects[0].availability tests', () => {
 
   it('Invalid - projects[0].availability.state has invalid type', () => {
     const invalid = stubSrFullModified('projects[0].availability.state', () => 55);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/availability/state');
@@ -39,7 +39,7 @@ describe('projects[0].availability tests', () => {
 
   it('Invalid - projects[0].availability.state has invalid value', () => {
     const invalid = stubSrFullModified('projects[0].availability.state', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be equal to one of the allowed values');
     expect(output[0].instancePath).toBe('/projects/0/availability/state');

--- a/src/ts/tests/projects/project/characteristics/test.spec.ts
+++ b/src/ts/tests/projects/project/characteristics/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('projects[0].characteristics tests', () => {
   it('Invalid - projects[0].characteristics is of invalid type', () => {
     const invalid = stubSrFullModified('projects[0].characteristics', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/characteristics');
@@ -17,7 +17,7 @@ describe('projects[0].characteristics tests', () => {
   it('Invalid - projects[0].characteristics has additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.projects![0].characteristics, { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/characteristics');
@@ -36,7 +36,7 @@ describe('projects[0].characteristics tests', () => {
         numberOfCommercialUnits: 'a'
       };
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].instancePath).toBe('/projects/0/characteristics/areaSiaNfFrom');
     expect(output[0].message).toBe('must be number');
@@ -69,7 +69,7 @@ describe('projects[0].characteristics tests', () => {
         numberOfCommercialUnits: -1
       };
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].instancePath).toBe('/projects/0/characteristics/areaSiaNfFrom');
     expect(output[0].message).toBe('must be >= 0');

--- a/src/ts/tests/projects/project/localizations/localization/attachments/directLinks/directLink/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/directLinks/directLink/test.spec.ts
@@ -2,7 +2,7 @@ import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('projects[0].localizations[0].attachments.directLinks[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.directLinks[0] must be object', () => {
@@ -10,7 +10,7 @@ describe('projects[0].localizations[0].attachments.directLinks[0] tests', () => 
       'projects[0].localizations[0].attachments.directLinks[0]',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/directLinks/0');
@@ -21,7 +21,7 @@ describe('projects[0].localizations[0].attachments.directLinks[0] tests', () => 
     _.assign(clone.projects![0].localizations![0].attachments!.directLinks![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/directLinks/0');
@@ -30,7 +30,7 @@ describe('projects[0].localizations[0].attachments.directLinks[0] tests', () => 
   it('Invalid - projects[0].localizations[0].attachments.directLinks[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.directLinks[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/directLinks/0');
@@ -41,7 +41,7 @@ describe('projects[0].localizations[0].attachments.directLinks[0] tests', () => 
       'projects[0].localizations[0].attachments.directLinks[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -54,7 +54,7 @@ describe('projects[0].localizations[0].attachments.directLinks[0] tests', () => 
       'projects[0].localizations[0].attachments.directLinks[0].title',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -65,7 +65,7 @@ describe('projects[0].localizations[0].attachments.directLinks[0] tests', () => 
   it('Valid - projects[0].localizations[0].attachments.directLinks[0].title is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.directLinks[0].title');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/directLinks/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/directLinks/test.spec.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
@@ -9,7 +9,7 @@ describe('projects[0].localizations[0].attachments.directLinks tests', () => {
       'projects[0].localizations[0].attachments.directLinks',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/directLinks');
@@ -20,7 +20,7 @@ describe('projects[0].localizations[0].attachments.directLinks tests', () => {
       'projects[0].localizations[0].attachments.directLinks',
       () => []
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/documents/document/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/documents/document/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -11,7 +11,7 @@ describe('projects[0].localizations[0].attachments.documents[0] tests', () => {
       'projects[0].localizations[0].attachments.documents[0]',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/documents/0');
@@ -22,7 +22,7 @@ describe('projects[0].localizations[0].attachments.documents[0] tests', () => {
     _.assign(clone.projects![0].localizations![0].attachments!.documents![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/documents/0');
@@ -31,7 +31,7 @@ describe('projects[0].localizations[0].attachments.documents[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.documents[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.documents[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/documents/0');
@@ -42,7 +42,7 @@ describe('projects[0].localizations[0].attachments.documents[0] tests', () => {
       'projects[0].localizations[0].attachments.documents[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/documents/0/url');
@@ -53,7 +53,7 @@ describe('projects[0].localizations[0].attachments.documents[0] tests', () => {
       'projects[0].localizations[0].attachments.documents[0].title',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -64,7 +64,7 @@ describe('projects[0].localizations[0].attachments.documents[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.documents[0].title is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.documents[0].title');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -75,7 +75,7 @@ describe('projects[0].localizations[0].attachments.documents[0] tests', () => {
       'projects[0].localizations[0].attachments.documents[0].mimeType',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -86,7 +86,7 @@ describe('projects[0].localizations[0].attachments.documents[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.documents[0].mimeType is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.documents[0].mimeType');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/documents/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/documents/test.spec.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
@@ -9,7 +9,7 @@ describe('projects[0].localizations[0].attachments.documents tests', () => {
       'projects[0].localizations[0].attachments.documents',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/documents');
@@ -20,7 +20,7 @@ describe('projects[0].localizations[0].attachments.documents tests', () => {
       'projects[0].localizations[0].attachments.documents',
       () => []
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/images/image/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/images/image/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -11,7 +11,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
       'projects[0].localizations[0].attachments.images[0]',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/images/0');
@@ -22,7 +22,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
     _.assign(clone.projects![0].localizations![0].attachments!.images![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/images/0');
@@ -31,7 +31,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.images[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.images[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/images/0');
@@ -42,7 +42,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
       'projects[0].localizations[0].attachments.images[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/images/0/url');
@@ -53,7 +53,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
       'projects[0].localizations[0].attachments.images[0].title',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/images/0/title');
@@ -62,7 +62,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.images[0].title is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.images[0].title');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -73,7 +73,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
       'projects[0].localizations[0].attachments.images[0].mimeType',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -84,7 +84,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.images[0].mimeType is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.images[0].mimeType');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -95,7 +95,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
       'projects[0].localizations[0].attachments.images[0].description',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -106,7 +106,7 @@ describe('projects[0].localizations[0].attachments.images[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.images[0].description is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.images[0].description');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/images/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/images/test.spec.ts
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('projects[0].localizations[0].attachments.images tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.images must be of type array', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.images', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/images');
@@ -13,7 +13,7 @@ describe('projects[0].localizations[0].attachments.images tests', () => {
 
   it('Invalid - projects[0].localizations[0].attachments.images can be an empty array', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.images', () => []);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/landRegisterExtracts/landRegisterExtract/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/landRegisterExtracts/landRegisterExtract/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -11,7 +11,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts[0] tests
       'projects[0].localizations[0].attachments.landRegisterExtracts[0]',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe(
@@ -24,7 +24,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts[0] tests
     _.assign(clone.projects![0].localizations![0].attachments!.landRegisterExtracts![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe(
@@ -35,7 +35,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts[0] tests
   it('Invalid - projects[0].localizations[0].attachments.landRegisterExtracts[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.landRegisterExtracts[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe(
@@ -48,7 +48,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts[0] tests
       'projects[0].localizations[0].attachments.landRegisterExtracts[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -61,7 +61,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts[0] tests
       'projects[0].localizations[0].attachments.landRegisterExtracts[0].title',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -72,7 +72,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts[0] tests
   it('Valid - projects[0].localizations[0].attachments.landRegisterExtracts[0].title is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.landRegisterExtracts[0].title');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -83,7 +83,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts[0] tests
       'projects[0].localizations[0].attachments.landRegisterExtracts[0].mimeType',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -94,7 +94,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts[0] tests
   it('Valid - projects[0].localizations[0].attachments.landRegisterExtracts[0].mimeType is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.landRegisterExtracts[0].mimeType');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/landRegisterExtracts/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/landRegisterExtracts/test.spec.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
@@ -9,7 +9,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts tests', 
       'projects[0].localizations[0].attachments.landRegisterExtracts',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe(
@@ -22,7 +22,7 @@ describe('projects[0].localizations[0].attachments.landRegisterExtracts tests', 
       'projects[0].localizations[0].attachments.landRegisterExtracts',
       () => []
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/links/link/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/links/link/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('projects[0].localizations[0].attachments.links[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.links[0] must be object', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.links[0]', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/links/0');
@@ -19,7 +19,7 @@ describe('projects[0].localizations[0].attachments.links[0] tests', () => {
     _.assign(clone.projects![0].localizations![0].attachments!.links![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/links/0');
@@ -28,7 +28,7 @@ describe('projects[0].localizations[0].attachments.links[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.links[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.links[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/links/0');
@@ -39,7 +39,7 @@ describe('projects[0].localizations[0].attachments.links[0] tests', () => {
       'projects[0].localizations[0].attachments.links[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/links/0/url');
@@ -50,7 +50,7 @@ describe('projects[0].localizations[0].attachments.links[0] tests', () => {
       'projects[0].localizations[0].attachments.links[0].title',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/links/0/title');
@@ -59,7 +59,7 @@ describe('projects[0].localizations[0].attachments.links[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.links[0].title is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.links[0].title');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/links/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/links/test.spec.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
 describe('projects[0].localizations[0].attachments.links tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.links must be of type array', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.links', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/links');
@@ -14,7 +14,7 @@ describe('projects[0].localizations[0].attachments.links tests', () => {
 
   it('Invalid - projects[0].localizations[0].attachments.links can be an empty array', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.links', () => []);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/logos/logo/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/logos/logo/test.spec.ts
@@ -2,12 +2,12 @@ import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('projects[0].localizations[0].attachments.logos[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.logos[0] must be object', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.logos[0]', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/logos/0');
@@ -18,7 +18,7 @@ describe('projects[0].localizations[0].attachments.logos[0] tests', () => {
     _.assign(clone.projects![0].localizations![0].attachments!.logos![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/logos/0');
@@ -27,7 +27,7 @@ describe('projects[0].localizations[0].attachments.logos[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.logos[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.logos[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/logos/0');
@@ -38,7 +38,7 @@ describe('projects[0].localizations[0].attachments.logos[0] tests', () => {
       'projects[0].localizations[0].attachments.logos[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/logos/0/url');
@@ -49,7 +49,7 @@ describe('projects[0].localizations[0].attachments.logos[0] tests', () => {
       'projects[0].localizations[0].attachments.logos[0].mimeType',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/logos/0/mimeType');
@@ -58,7 +58,7 @@ describe('projects[0].localizations[0].attachments.logos[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.logos[0].mimeType is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.logos[0].mimeType');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/logos/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/logos/test.spec.ts
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('projects[0].localizations[0].attachments.logos tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.images must be of type array', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.logos', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/logos');
@@ -13,7 +13,7 @@ describe('projects[0].localizations[0].attachments.logos tests', () => {
 
   it('Invalid - projects[0].localizations[0].attachments.images can be an empty logos', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.logos', () => []);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/plans/plan/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/plans/plan/test.spec.ts
@@ -3,12 +3,12 @@ import _ from 'lodash';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('projects[0].localizations[0].attachments.plans[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.plans[0] must be object', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.plans[0]', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/plans/0');
@@ -19,7 +19,7 @@ describe('projects[0].localizations[0].attachments.plans[0] tests', () => {
     _.assign(clone.projects![0].localizations![0].attachments!.plans![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/plans/0');
@@ -28,7 +28,7 @@ describe('projects[0].localizations[0].attachments.plans[0] tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.plans[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.plans[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/plans/0');
@@ -39,7 +39,7 @@ describe('projects[0].localizations[0].attachments.plans[0] tests', () => {
       'projects[0].localizations[0].attachments.plans[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/plans/0/url');
@@ -50,7 +50,7 @@ describe('projects[0].localizations[0].attachments.plans[0] tests', () => {
       'projects[0].localizations[0].attachments.plans[0].title',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/plans/0/title');
@@ -59,7 +59,7 @@ describe('projects[0].localizations[0].attachments.plans[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.plans[0].title is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.plans[0].title');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -70,7 +70,7 @@ describe('projects[0].localizations[0].attachments.plans[0] tests', () => {
       'projects[0].localizations[0].attachments.plans[0].mimeType',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/plans/0/mimeType');
@@ -79,7 +79,7 @@ describe('projects[0].localizations[0].attachments.plans[0] tests', () => {
   it('Valid - projects[0].localizations[0].attachments.plans[0].mimeType is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.plans[0].mimeType');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/plans/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/plans/test.spec.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
 describe('projects[0].localizations[0].attachments.plans tests', () => {
   it('Invalid - projects[0].localizations[0].attachments.plans must be of type array', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.plans', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/plans');
@@ -14,7 +14,7 @@ describe('projects[0].localizations[0].attachments.plans tests', () => {
 
   it('Invalid - projects[0].localizations[0].attachments.plans can be an empty array', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments.plans', () => []);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('projects[0].localizations[0].attachments tests', () => {
   it('Invalid - projects[0].localizations[0].attachments must be object', () => {
     const clone = stubSrFullModified('projects[0].localizations[0].attachments', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments');
@@ -19,7 +19,7 @@ describe('projects[0].localizations[0].attachments tests', () => {
     _.assign(clone.projects![0].localizations![0].attachments, {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments');
@@ -27,7 +27,7 @@ describe('projects[0].localizations[0].attachments tests', () => {
 
   it('Valid - projects[0].localizations[0].attachments can be an empty object', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].attachments', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/virtualTourLinks/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/virtualTourLinks/test.spec.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
@@ -9,7 +9,7 @@ describe('projects[0].localizations[0].attachments.virtualTourLinks tests', () =
       'projects[0].localizations[0].attachments.virtualTourLinks',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/virtualTourLinks');
@@ -20,7 +20,7 @@ describe('projects[0].localizations[0].attachments.virtualTourLinks tests', () =
       'projects[0].localizations[0].attachments.virtualTourLinks',
       () => []
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/virtualTourLinks/virtualTourLink/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/virtualTourLinks/virtualTourLink/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -11,7 +11,7 @@ describe('projects[0].localizations[0].attachments.virtualTourLinks[0] tests', (
       'projects[0].localizations[0].attachments.virtualTourLinks[0]',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe(
@@ -24,7 +24,7 @@ describe('projects[0].localizations[0].attachments.virtualTourLinks[0] tests', (
     _.assign(clone.projects![0].localizations![0].attachments!.virtualTourLinks![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe(
@@ -35,7 +35,7 @@ describe('projects[0].localizations[0].attachments.virtualTourLinks[0] tests', (
   it('Invalid - projects[0].localizations[0].attachments.virtualTourLinks[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.virtualTourLinks[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe(
@@ -48,7 +48,7 @@ describe('projects[0].localizations[0].attachments.virtualTourLinks[0] tests', (
       'projects[0].localizations[0].attachments.virtualTourLinks[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -61,7 +61,7 @@ describe('projects[0].localizations[0].attachments.virtualTourLinks[0] tests', (
       'projects[0].localizations[0].attachments.virtualTourLinks[0].title',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -72,7 +72,7 @@ describe('projects[0].localizations[0].attachments.virtualTourLinks[0] tests', (
   it('Valid - projects[0].localizations[0].attachments.virtualTourLinks[0].title is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.virtualTourLinks[0].title');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/youTubeLinks/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/youTubeLinks/test.spec.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
@@ -9,7 +9,7 @@ describe('projects[0].localizations[0].attachments.youTubeLinks tests', () => {
       'projects[0].localizations[0].attachments.youTubeLinks',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/youTubeLinks');
@@ -20,7 +20,7 @@ describe('projects[0].localizations[0].attachments.youTubeLinks tests', () => {
       'projects[0].localizations[0].attachments.youTubeLinks',
       () => []
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/attachments/youTubeLinks/youTubeLink/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/attachments/youTubeLinks/youTubeLink/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -11,7 +11,7 @@ describe('projects[0].localizations[0].attachments.youTubeLinks[0] tests', () =>
       'projects[0].localizations[0].attachments.youTubeLinks[0]',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/youTubeLinks/0');
@@ -22,7 +22,7 @@ describe('projects[0].localizations[0].attachments.youTubeLinks[0] tests', () =>
     _.assign(clone.projects![0].localizations![0].attachments!.youTubeLinks![0], {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/youTubeLinks/0');
@@ -31,7 +31,7 @@ describe('projects[0].localizations[0].attachments.youTubeLinks[0] tests', () =>
   it('Invalid - projects[0].localizations[0].attachments.youTubeLinks[0].url must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.youTubeLinks[0].url');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/attachments/youTubeLinks/0');
@@ -42,7 +42,7 @@ describe('projects[0].localizations[0].attachments.youTubeLinks[0] tests', () =>
       'projects[0].localizations[0].attachments.youTubeLinks[0].url',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -55,7 +55,7 @@ describe('projects[0].localizations[0].attachments.youTubeLinks[0] tests', () =>
       'projects[0].localizations[0].attachments.youTubeLinks[0].title',
       () => 33
     );
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -66,7 +66,7 @@ describe('projects[0].localizations[0].attachments.youTubeLinks[0] tests', () =>
   it('Valid - projects[0].localizations[0].attachments.youTubeLinks[0].title is optional', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].attachments.youTubeLinks[0].title');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/localizations/localization/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/localization/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('projects[0].localizations[0] tests', () => {
   it('Invalid - projects[0].localizations[0] must be object', () => {
     const clone = stubSrFullModified('projects[0].localizations[0]', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0');
@@ -17,7 +17,7 @@ describe('projects[0].localizations[0] tests', () => {
   it('Invalid - projects[0].localizations[0] cannot have additional properties', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(clone.projects![0].localizations![0], { additionalProperty: 'additionalProperty' });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0');
@@ -26,7 +26,7 @@ describe('projects[0].localizations[0] tests', () => {
   it('Invalid - projects[0].localizations[0].languageCode must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].localizations[0].languageCode');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'languageCode'");
     expect(output[0].instancePath).toBe('/projects/0/localizations/0');
@@ -34,7 +34,7 @@ describe('projects[0].localizations[0] tests', () => {
 
   it('Invalid - projects[0].localizations[0].languageCode must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].languageCode', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/languageCode');
@@ -42,7 +42,7 @@ describe('projects[0].localizations[0] tests', () => {
 
   it('Invalid - projects[0].localizations[0].languageCode must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].languageCode', () => '33');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[a-z]{2}$"');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/languageCode');
@@ -50,7 +50,7 @@ describe('projects[0].localizations[0] tests', () => {
 
   it('Invalid - projects[0].localizations[0].languageCode must have', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].languageCode', () => '33');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[a-z]{2}$"');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/languageCode');
@@ -58,7 +58,7 @@ describe('projects[0].localizations[0] tests', () => {
 
   it('Invalid - projects[0].localizations[0].languageCode must not have more than 2 characters', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].languageCode', () => 'ffff');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have more than 2 characters');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/languageCode');
@@ -66,7 +66,7 @@ describe('projects[0].localizations[0] tests', () => {
 
   it('Invalid - projects[0].localizations[0].languageCode must not have fewer than 2 characters', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].languageCode', () => 'f');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have fewer than 2 characters');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/languageCode');
@@ -74,7 +74,7 @@ describe('projects[0].localizations[0] tests', () => {
 
   it('Invalid - projects[0].localizations[0].title must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].title', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/title');
@@ -82,7 +82,7 @@ describe('projects[0].localizations[0] tests', () => {
 
   it('Invalid - projects[0].localizations[0].excerpt must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].excerpt', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/excerpt');
@@ -90,7 +90,7 @@ describe('projects[0].localizations[0] tests', () => {
 
   it('Invalid - projects[0].localizations[0].description must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].localizations[0].description', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/localizations/0/description');

--- a/src/ts/tests/projects/project/localizations/test.spec.ts
+++ b/src/ts/tests/projects/project/localizations/test.spec.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
 describe('projects[0].localizations tests', () => {
   it('Invalid - projects[0].localizations must be of type array', () => {
     const clone = stubSrFullModified('projects[0].localizations', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects/0/localizations');
@@ -14,7 +14,7 @@ describe('projects[0].localizations tests', () => {
 
   it('Invalid - projects[0].localizations can be an empty array', () => {
     const clone = stubSrFullModified('projects[0].localizations', () => []);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/projects/project/prices/buy/test.spec.ts
+++ b/src/ts/tests/projects/project/prices/buy/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0].prices.buy tests', () => {
   it('Invalid - projects[0].prices.buy cannot have additional properties', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(clone.projects![0].prices!.buy, { additionalProperty: 'additionalProperty' });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/prices/buy');
@@ -17,7 +17,7 @@ describe('projects[0].prices.buy tests', () => {
 
   it('Invalid - projects[0].prices.buy must be of type object', () => {
     const clone = stubSrFullModified('projects[0].prices.buy', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/prices/buy');
@@ -26,7 +26,7 @@ describe('projects[0].prices.buy tests', () => {
   it('Invalid - projects[0].prices.buy.priceFrom must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].prices.buy.priceFrom');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'priceFrom'");
     expect(output[0].instancePath).toBe('/projects/0/prices/buy');
@@ -34,7 +34,7 @@ describe('projects[0].prices.buy tests', () => {
 
   it('Invalid - projects[0].prices.buy.priceFrom must be 0 or higher', () => {
     const clone = stubSrFullModified('projects[0].prices.buy.priceFrom', () => -1);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be >= 0');
     expect(output[0].instancePath).toBe('/projects/0/prices/buy/priceFrom');
@@ -43,7 +43,7 @@ describe('projects[0].prices.buy tests', () => {
   it('Invalid - projects[0].prices.buy.priceTo must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].prices.buy.priceTo');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'priceTo'");
     expect(output[0].instancePath).toBe('/projects/0/prices/buy');
@@ -51,7 +51,7 @@ describe('projects[0].prices.buy tests', () => {
 
   it('Invalid - projects[0].prices.buy.priceTo must be 0 or higher', () => {
     const clone = stubSrFullModified('projects[0].prices.buy.priceTo', () => -1);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be >= 0');
     expect(output[0].instancePath).toBe('/projects/0/prices/buy/priceTo');
@@ -59,7 +59,7 @@ describe('projects[0].prices.buy tests', () => {
 
   it('Invalid - projects[0].prices.buy.referring must be of type string', () => {
     const clone = stubSrFullModified('projects[0].prices.buy.referring', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/prices/buy/referring');
@@ -68,7 +68,7 @@ describe('projects[0].prices.buy tests', () => {
   it('Invalid - projects[0].prices.buy.referring must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].prices.buy.referring');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'referring'");
     expect(output[0].instancePath).toBe('/projects/0/prices/buy');
@@ -76,7 +76,7 @@ describe('projects[0].prices.buy tests', () => {
 
   it('Invalid - projects[0].prices.buy.referring must be equal to one of the allowed values', () => {
     const invalid = stubSrFullModified('projects[0].prices.buy.referring', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be equal to one of the allowed values');
     expect(output[0].instancePath).toBe('/projects/0/prices/buy/referring');

--- a/src/ts/tests/projects/project/prices/rent/test.spec.ts
+++ b/src/ts/tests/projects/project/prices/rent/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0].prices.rent tests', () => {
   it('Invalid - projects[0].prices.rent cannot have additional properties', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(clone.projects![0].prices!.rent, { additionalProperty: 'additionalProperty' });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent');
@@ -17,7 +17,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent must be of type object', () => {
     const clone = stubSrFullModified('projects[0].prices.rent', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent');
@@ -26,7 +26,7 @@ describe('projects[0].prices.rent tests', () => {
   it('Invalid - projects[0].prices.rent.netFrom must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].prices.rent.netFrom');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'netFrom'");
     expect(output[0].instancePath).toBe('/projects/0/prices/rent');
@@ -34,7 +34,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent.netFrom must be 0 or higher', () => {
     const clone = stubSrFullModified('projects[0].prices.rent.netFrom', () => -1);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be >= 0');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent/netFrom');
@@ -42,7 +42,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent.netFrom must be of type integer', () => {
     const clone = stubSrFullModified('projects[0].prices.rent.netFrom', () => 'r');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be integer');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent/netFrom');
@@ -51,7 +51,7 @@ describe('projects[0].prices.rent tests', () => {
   it('Invalid - projects[0].prices.rent.netTo must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].prices.rent.netTo');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'netTo'");
     expect(output[0].instancePath).toBe('/projects/0/prices/rent');
@@ -59,7 +59,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent.netTo must be 0 or higher', () => {
     const clone = stubSrFullModified('projects[0].prices.rent.netTo', () => -1);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be >= 0');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent/netTo');
@@ -67,7 +67,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent.netTo must be of type integer', () => {
     const clone = stubSrFullModified('projects[0].prices.rent.netTo', () => 'r');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be integer');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent/netTo');
@@ -75,7 +75,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent.interval must be of type string', () => {
     const clone = stubSrFullModified('projects[0].prices.rent.interval', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent/interval');
@@ -83,7 +83,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent.interval must be equal to one of the allowed values', () => {
     const invalid = stubSrFullModified('projects[0].prices.rent.interval', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be equal to one of the allowed values');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent/interval');
@@ -91,7 +91,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent.referring must be of type string', () => {
     const clone = stubSrFullModified('projects[0].prices.rent.referring', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent/referring');
@@ -99,7 +99,7 @@ describe('projects[0].prices.rent tests', () => {
 
   it('Invalid - projects[0].prices.rent.referring must be equal to one of the allowed values', () => {
     const invalid = stubSrFullModified('projects[0].prices.rent.referring', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be equal to one of the allowed values');
     expect(output[0].instancePath).toBe('/projects/0/prices/rent/referring');

--- a/src/ts/tests/projects/project/prices/test.spec.ts
+++ b/src/ts/tests/projects/project/prices/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0].prices tests', () => {
   it('Invalid - projects[0].prices cannot have additional properties', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(clone.projects![0].prices, { additionalProperty: 'additionalProperty' });
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/prices');
@@ -17,7 +17,7 @@ describe('projects[0].prices tests', () => {
 
   it('Invalid - projects[0].prices must be of type object', () => {
     const clone = stubSrFullModified('projects[0].prices', () => 33);
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/prices');
@@ -26,7 +26,7 @@ describe('projects[0].prices tests', () => {
   it('Invalid - projects[0].prices.currency must be present', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].prices.currency');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output[0].message).toBe("must have required property 'currency'");
     expect(output[0].instancePath).toBe('/projects/0/prices');
@@ -34,7 +34,7 @@ describe('projects[0].prices tests', () => {
 
   it('Invalid - projects[0].prices.currency must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].prices.currency', () => 'fff.fff');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[A-Z]{3}$"');
     expect(output[0].instancePath).toBe('/projects/0/prices/currency');

--- a/src/ts/tests/projects/project/seller/organization/address/geo/test.spec.ts
+++ b/src/ts/tests/projects/project/seller/organization/address/geo/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -11,7 +11,7 @@ describe('projects[0].seller.organization.address.geo tests', () => {
     _.assign(invalid.projects![0].seller!.organization!.address!.geo, {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/geo');
@@ -19,7 +19,7 @@ describe('projects[0].seller.organization.address.geo tests', () => {
 
   it('Invalid - projects[0].seller.organization.address.geo must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.address.geo', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/geo');
@@ -28,7 +28,7 @@ describe('projects[0].seller.organization.address.geo tests', () => {
   it('Valid - projects[0].seller.organization.address.geo.elevation can be omitted', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].seller.organization.address.geo.elevation');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -39,7 +39,7 @@ describe('projects[0].seller.organization.address.geo tests', () => {
       'projects[0].seller.organization.address.geo.elevation',
       () => 'invalid'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be number');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/geo/elevation');
@@ -48,7 +48,7 @@ describe('projects[0].seller.organization.address.geo tests', () => {
   it('Invalid - projects[0].seller.organization.address.geo.latitude must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].seller.organization.address.geo.latitude');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'latitude'");
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/geo');
@@ -59,7 +59,7 @@ describe('projects[0].seller.organization.address.geo tests', () => {
       'projects[0].seller.organization.address.geo.latitude',
       () => 'invalid'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be number');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/geo/latitude');
@@ -68,7 +68,7 @@ describe('projects[0].seller.organization.address.geo tests', () => {
   it('Invalid - projects[0].seller.organization.address.geo.longitude must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].seller.organization.address.geo.longitude');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'longitude'");
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/geo');
@@ -79,7 +79,7 @@ describe('projects[0].seller.organization.address.geo tests', () => {
       'projects[0].seller.organization.address.geo.longitude',
       () => 'invalid'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be number');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/geo/longitude');

--- a/src/ts/tests/projects/project/seller/organization/address/test.spec.ts
+++ b/src/ts/tests/projects/project/seller/organization/address/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('projects[0].seller.organization.address tests', () => {
   it('Valid - projects[0].seller.organization.address can be an empty object', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.address', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -19,7 +19,7 @@ describe('projects[0].seller.organization.address tests', () => {
     _.assign(invalid.projects![0].seller!.organization!.address, {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address');
@@ -27,7 +27,7 @@ describe('projects[0].seller.organization.address tests', () => {
 
   it('Invalid - projects[0].seller.organization.address must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.address', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address');
@@ -38,7 +38,7 @@ describe('projects[0].seller.organization.address tests', () => {
       'projects[0].seller.organization.address.countryCode',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/countryCode');
@@ -49,7 +49,7 @@ describe('projects[0].seller.organization.address tests', () => {
       'projects[0].seller.organization.address.countryCode',
       () => 'fff.fff'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "[A-Z]{2}"');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/countryCode');
@@ -60,7 +60,7 @@ describe('projects[0].seller.organization.address tests', () => {
       'projects[0].seller.organization.address.locality',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/locality');
@@ -68,7 +68,7 @@ describe('projects[0].seller.organization.address tests', () => {
 
   it('Invalid - projects[0].seller.organization.address.region must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.address.region', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/region');
@@ -79,7 +79,7 @@ describe('projects[0].seller.organization.address tests', () => {
       'projects[0].seller.organization.address.postalCode',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/postalCode');
@@ -90,7 +90,7 @@ describe('projects[0].seller.organization.address tests', () => {
       'projects[0].seller.organization.address.postOfficeBoxNumber',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe(
@@ -100,7 +100,7 @@ describe('projects[0].seller.organization.address tests', () => {
 
   it('Invalid - projects[0].seller.organization.address.street must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.address.street', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/street');
@@ -111,7 +111,7 @@ describe('projects[0].seller.organization.address tests', () => {
       'projects[0].seller.organization.address.streetNumber',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/streetNumber');
@@ -122,7 +122,7 @@ describe('projects[0].seller.organization.address tests', () => {
       'projects[0].seller.organization.address.streetAddition',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/streetAddition');
@@ -133,7 +133,7 @@ describe('projects[0].seller.organization.address tests', () => {
       'projects[0].seller.organization.address.subunit',
       () => 'a'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be integer');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/address/subunit');

--- a/src/ts/tests/projects/project/seller/organization/contactPerson/test.spec.ts
+++ b/src/ts/tests/projects/project/seller/organization/contactPerson/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0].seller.contactPerson tests', () => {
   it('Valid - projects[0].seller.contactPerson can be omitted', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].seller.contactPerson');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -17,7 +17,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Valid - projects[0].seller.contactPerson can be empty object', () => {
     const clone = stubSrFullModified('projects[0].seller.contactPerson', () => ({}));
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -28,7 +28,7 @@ describe('projects[0].seller.contactPerson tests', () => {
     _.assign(invalid.projects![0].seller!.contactPerson, {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson');
@@ -36,7 +36,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson');
@@ -44,7 +44,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.gender must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.gender', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/gender');
@@ -52,7 +52,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.function must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.function', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/function');
@@ -60,7 +60,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.givenName must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.givenName', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/givenName');
@@ -68,7 +68,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.familyName must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.familyName', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/familyName');
@@ -76,7 +76,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.note must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.note', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/note');
@@ -84,7 +84,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.email must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.email', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/email');
@@ -92,7 +92,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.email must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.email', () => 'fff.fff');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "[^@]+@[^\\.]+\\..+"');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/email');
@@ -100,7 +100,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.phone must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.phone', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/phone');
@@ -108,7 +108,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.phone must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.phone', () => '44');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[+]?([0-9] )*[0-9]{3,}$"');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/phone');
@@ -116,7 +116,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.mobile must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.mobile', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/mobile');
@@ -124,7 +124,7 @@ describe('projects[0].seller.contactPerson tests', () => {
 
   it('Invalid - projects[0].seller.contactPerson.mobile must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.contactPerson.mobile', () => '44');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[+]?([0-9] )*[0-9]{3,}$"');
     expect(output[0].instancePath).toBe('/projects/0/seller/contactPerson/mobile');

--- a/src/ts/tests/projects/project/seller/organization/inquiryPerson/test.spec.ts
+++ b/src/ts/tests/projects/project/seller/organization/inquiryPerson/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
   it('Valid - projects[0].seller.inquiryPerson can be omitted', () => {
     const clone = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(clone, 'projects[0].seller.inquiryPerson');
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -17,7 +17,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Valid - projects[0].seller.inquiryPerson can be empty object', () => {
     const clone = stubSrFullModified('projects[0].seller.inquiryPerson', () => ({}));
-    const output = validateSwissRetsObject(clone);
+    const output = validateSwissRets(clone);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -28,7 +28,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
     _.assign(invalid.projects![0].seller!.inquiryPerson, {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson');
@@ -36,7 +36,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson');
@@ -44,7 +44,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.gender must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.gender', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/gender');
@@ -52,7 +52,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.function must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.function', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/function');
@@ -60,7 +60,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.givenName must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.givenName', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/givenName');
@@ -68,7 +68,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.familyName must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.familyName', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/familyName');
@@ -76,7 +76,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.note must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.note', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/note');
@@ -84,7 +84,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.email must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.email', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/email');
@@ -92,7 +92,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.email must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.email', () => 'fff.fff');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "[^@]+@[^\\.]+\\..+"');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/email');
@@ -100,7 +100,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.phone must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.phone', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/phone');
@@ -108,7 +108,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.phone must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.phone', () => '44');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[+]?([0-9] )*[0-9]{3,}$"');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/phone');
@@ -116,7 +116,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.mobile must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.mobile', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/mobile');
@@ -124,7 +124,7 @@ describe('projects[0].seller.inquiryPerson tests', () => {
 
   it('Invalid - projects[0].seller.inquiryPerson.mobile must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.inquiryPerson.mobile', () => '44');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[+]?([0-9] )*[0-9]{3,}$"');
     expect(output[0].instancePath).toBe('/projects/0/seller/inquiryPerson/mobile');

--- a/src/ts/tests/projects/project/seller/organization/test.spec.ts
+++ b/src/ts/tests/projects/project/seller/organization/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0].seller.organization tests', () => {
   it('Valid - projects[0].seller.organization can be omitted', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].seller.organization');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -17,7 +17,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Valid - projects[0].seller.organization can be empty object', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -28,7 +28,7 @@ describe('projects[0].seller.organization tests', () => {
     _.assign(invalid.projects![0].seller!.organization, {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization');
@@ -36,7 +36,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization');
@@ -44,7 +44,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.legalName must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.legalName', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/legalName');
@@ -52,7 +52,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.brand must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.brand', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/brand');
@@ -60,7 +60,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.email must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.email', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/email');
@@ -68,7 +68,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.email must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.email', () => 'fff.fff');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "[^@]+@[^\\.]+\\..+"');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/email');
@@ -76,7 +76,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.emailRem must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.emailRem', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/emailRem');
@@ -84,7 +84,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.emailRem must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.emailRem', () => 'fff.fff');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "[^@]+@[^\\.]+\\..+"');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/emailRem');
@@ -92,7 +92,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.phone must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.phone', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/phone');
@@ -100,7 +100,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.phone must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.phone', () => '44');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[+]?([0-9] )*[0-9]{3,}$"');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/phone');
@@ -108,7 +108,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.mobile must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.mobile', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/mobile');
@@ -116,7 +116,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.mobile must be of certain pattern', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.mobile', () => '44');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[+]?([0-9] )*[0-9]{3,}$"');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/mobile');
@@ -124,7 +124,7 @@ describe('projects[0].seller.organization tests', () => {
 
   it('Invalid - projects[0].seller.organization.id must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.id', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/id');

--- a/src/ts/tests/projects/project/seller/organization/website/test.spec.ts
+++ b/src/ts/tests/projects/project/seller/organization/website/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0].seller.organization.website tests', () => {
   it('Invalid - projects[0].seller.organization.website.url must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].seller.organization.website.url');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'url'");
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/website');
@@ -18,7 +18,7 @@ describe('projects[0].seller.organization.website tests', () => {
   it('Valid - projects[0].seller.organization.website.title can be omitted', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].seller.organization.website.title');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -29,7 +29,7 @@ describe('projects[0].seller.organization.website tests', () => {
     _.assign(invalid.projects![0].seller!.organization!.website, {
       additionalProperty: 'additionalProperty'
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/website');
@@ -37,7 +37,7 @@ describe('projects[0].seller.organization.website tests', () => {
 
   it('Invalid - projects[0].seller.organization.website must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.website', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/website');
@@ -45,7 +45,7 @@ describe('projects[0].seller.organization.website tests', () => {
 
   it('Invalid - projects[0].seller.organization.website.title must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.website.title', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/website/title');
@@ -53,7 +53,7 @@ describe('projects[0].seller.organization.website tests', () => {
 
   it('Invalid - projects[0].seller.organization.website.url must be of type string', () => {
     const invalid = stubSrFullModified('projects[0].seller.organization.website.url', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/seller/organization/website/url');

--- a/src/ts/tests/projects/project/seller/test.spec.ts
+++ b/src/ts/tests/projects/project/seller/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0].seller tests', () => {
   it('Valid - projects[0].seller can be omitted', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'projects[0].seller');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -17,7 +17,7 @@ describe('projects[0].seller tests', () => {
 
   it('Valid - projects[0].seller can be empty object', () => {
     const invalid = stubSrFullModified('projects[0].seller', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -26,7 +26,7 @@ describe('projects[0].seller tests', () => {
   it('Invalid - projects[0].seller cannot have additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.projects![0].seller, { additionalProperty: 'additionalProperty' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0/seller');
@@ -34,7 +34,7 @@ describe('projects[0].seller tests', () => {
 
   it('Invalid - projects[0].seller must be of type object', () => {
     const invalid = stubSrFullModified('projects[0].seller', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0/seller');

--- a/src/ts/tests/projects/project/test.spec.ts
+++ b/src/ts/tests/projects/project/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('projects[0] tests', () => {
   it('Invalid - projects[0] must be object', () => {
     const invalid = stubSrFullModified('properties', () => []);
     _.update(invalid, 'projects[0]', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/projects/0');
@@ -18,7 +18,7 @@ describe('projects[0] tests', () => {
   it('Invalid - projects[0] has additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.projects![0], { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/projects/0');
@@ -26,7 +26,7 @@ describe('projects[0] tests', () => {
 
   it('Invalid - projects[0].id has invalid type', () => {
     const invalid = stubSrFullModified('projects[0].id', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/id');
@@ -34,7 +34,7 @@ describe('projects[0] tests', () => {
 
   it('Invalid - projects[0].referenceId has invalid type', () => {
     const invalid = stubSrFullModified('projects[0].referenceId', () => 22);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/projects/0/referenceId');
@@ -42,7 +42,7 @@ describe('projects[0] tests', () => {
 
   it('Invalid - projects[0].constructionStatus has invalid value', () => {
     const invalid = stubSrFullModified('projects[0].constructionStatus', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be equal to one of the allowed values');
     expect(output[0].instancePath).toBe('/projects/0/constructionStatus');

--- a/src/ts/tests/projects/test.spec.ts
+++ b/src/ts/tests/projects/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -10,7 +10,7 @@ describe('projects tests', () => {
     const invalid = stubSrFullModified('projects', () => {
       return {};
     });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/projects');
@@ -20,7 +20,7 @@ describe('projects tests', () => {
     const valid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.update(valid, 'projects', () => []);
     _.update(valid, 'properties', () => []);
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/properties/property/bfs/test.spec.ts
+++ b/src/ts/tests/properties/property/bfs/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('properties[0].publishers[0] tests', () => {
   it('Invalid - properties[0].publishers[0] must be object', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0]', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0');
@@ -17,7 +17,7 @@ describe('properties[0].publishers[0] tests', () => {
   it('Invalid - properties[0].publishers[0] must not have additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.properties![0].publishers![0], { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0');

--- a/src/ts/tests/properties/property/publishers/publisher/options/option/test.spec.ts
+++ b/src/ts/tests/properties/property/publishers/publisher/options/option/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('properties[0].publishers[0].options[0] tests', () => {
   it('Invalid - properties[0].publishers[0].options[0] must be object', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].options[0]', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0');
@@ -17,7 +17,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
   it('Invalid - properties[0].publishers[0].options[0] must not have additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.properties![0].publishers![0].options![0], { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0');
@@ -26,7 +26,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
   it('Invalid - properties[0].publishers[0].options[0].key must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].options[0].key');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'key'");
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0');
@@ -34,7 +34,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
 
   it('Invalid - properties[0].publishers[0].options[0].key must be string', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].options[0].key', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/key');
@@ -43,7 +43,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
   it('Invalid - properties[0].publishers[0].options[0].value must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].options[0].value');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'value'");
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0');
@@ -51,7 +51,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
 
   it('Invalid - properties[0].publishers[0].options[0].value must be string', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].options[0].value', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/value');
@@ -60,7 +60,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
   it('Valid - properties[0].publishers[0].options[0].start is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].options[0].start');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -68,7 +68,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
 
   it('Invalid - properties[0].publishers[0].options[0].start must be string', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].options[0].start', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/start');
@@ -79,7 +79,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
       'properties[0].publishers[0].options[0].start',
       () => '1-1-1 99:99:99'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match format "date-time"');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/start');
@@ -88,7 +88,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
   it('Valid - properties[0].publishers[0].options[0].expiration is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].options[0].expiration');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -99,7 +99,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
       'properties[0].publishers[0].options[0].expiration',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/expiration');
@@ -110,7 +110,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
       'properties[0].publishers[0].options[0].expiration',
       () => '1-1-1 99:99:99'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match format "date-time"');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/expiration');
@@ -119,7 +119,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
   it('Valid - properties[0].publishers[0].options[0].languageCode is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].options[0].languageCode');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -130,7 +130,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
       'properties[0].publishers[0].options[0].languageCode',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/languageCode');
@@ -141,7 +141,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
       'properties[0].publishers[0].options[0].languageCode',
       () => 'cbr'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have more than 2 characters');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/languageCode');
@@ -152,7 +152,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
       'properties[0].publishers[0].options[0].languageCode',
       () => 'c'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have fewer than 2 characters');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/languageCode');
@@ -163,7 +163,7 @@ describe('properties[0].publishers[0].options[0] tests', () => {
       'properties[0].publishers[0].options[0].languageCode',
       () => '%&'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match pattern "^[a-z]{2}$"');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options/0/languageCode');

--- a/src/ts/tests/properties/property/publishers/publisher/options/test.spec.ts
+++ b/src/ts/tests/properties/property/publishers/publisher/options/test.spec.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
 describe('properties[0].publishers[0].options tests', () => {
   it('Invalid - properties[0].publishers[0].options must be array', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].options', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/options');
@@ -14,7 +14,7 @@ describe('properties[0].publishers[0].options tests', () => {
 
   it('Valid - properties[0].publishers[0].options can be empty array', () => {
     const valid = stubSrFullModified('properties[0].publishers[0].options', () => []);
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/properties/property/publishers/publisher/promotions/promotion/test.spec.ts
+++ b/src/ts/tests/properties/property/publishers/publisher/promotions/promotion/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('properties[0].publishers[0].promotions[0] tests', () => {
   it('Invalid - properties[0].publishers[0].promotions[0] must be object', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].promotions[0]', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0');
@@ -17,7 +17,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
   it('Invalid - properties[0].publishers[0].promotions[0] must not have additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.properties![0].publishers![0].promotions![0], { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0');
@@ -25,7 +25,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
 
   it('Invalid - properties[0].publishers[0].promotions[0].name must be string', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].promotions[0].name', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0/name');
@@ -34,7 +34,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
   it('Valid - properties[0].publishers[0].promotions[0].name is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].promotions[0].name');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -42,7 +42,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
 
   it('Invalid - properties[0].publishers[0].promotions[0].start must be string', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].promotions[0].start', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0/start');
@@ -51,7 +51,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
   it('Valid - properties[0].publishers[0].options[0].promotions[0].start is not optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].promotions[0].start');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output[0].message).toBe(`must have required property 'start'`);
@@ -63,7 +63,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
       'properties[0].publishers[0].promotions[0].start',
       () => '1-1-1 99:99:99'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match format "date-time"');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0/start');
@@ -74,7 +74,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
       'properties[0].publishers[0].promotions[0].start',
       () => '11-11-11 11:11:11'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match format "date-time"');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0/start');
@@ -85,7 +85,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
       'properties[0].publishers[0].promotions[0].expiration',
       () => 33
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0/expiration');
@@ -94,7 +94,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
   it('Valid - properties[0].publishers[0].options[0].promotions[0].expiration is not optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].promotions[0].expiration');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output[0].message).toBe(`must have required property 'expiration'`);
@@ -108,7 +108,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
       'properties[0].publishers[0].promotions[0].expiration',
       () => '1-1-1 99:99:99'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match format "date-time"');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0/expiration');
@@ -121,7 +121,7 @@ describe('properties[0].publishers[0].promotions[0] tests', () => {
       'properties[0].publishers[0].promotions[0].expiration',
       () => '11-11-11 11:11:11'
     );
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match format "date-time"');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions/0/expiration');

--- a/src/ts/tests/properties/property/publishers/publisher/promotions/test.spec.ts
+++ b/src/ts/tests/properties/property/publishers/publisher/promotions/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('properties[0].publishers[0].promotions tests', () => {
   it('Invalid - properties[0].publishers[0].promotions must be array', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].promotions', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/promotions');
@@ -16,7 +16,7 @@ describe('properties[0].publishers[0].promotions tests', () => {
 
   it('Valid - properties[0].publishers[0].promotions can be empty array', () => {
     const valid = stubSrFullModified('properties[0].publishers[0].promotions', () => []);
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -25,7 +25,7 @@ describe('properties[0].publishers[0].promotions tests', () => {
   it('Valid - properties[0].publishers[0].promotions is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].promotions');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/properties/property/publishers/publisher/test.spec.ts
+++ b/src/ts/tests/properties/property/publishers/publisher/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -8,7 +8,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('properties[0].publishers[0] tests', () => {
   it('Invalid - properties[0].publishers[0] must be object', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0]', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0');
@@ -17,7 +17,7 @@ describe('properties[0].publishers[0] tests', () => {
   it('Invalid - properties[0].publishers[0] must not have additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.properties![0].publishers![0], { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0');
@@ -26,7 +26,7 @@ describe('properties[0].publishers[0] tests', () => {
   it('Invalid - properties[0].publishers[0].id must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers[0].id');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'id'");
     expect(output[0].instancePath).toBe('/properties/0/publishers/0');
@@ -34,7 +34,7 @@ describe('properties[0].publishers[0] tests', () => {
 
   it('Invalid - properties[0].publishers[0].id must be string', () => {
     const invalid = stubSrFullModified('properties[0].publishers[0].id', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/publishers/0/id');

--- a/src/ts/tests/properties/property/publishers/test.spec.ts
+++ b/src/ts/tests/properties/property/publishers/test.spec.ts
@@ -1,6 +1,6 @@
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ describe('properties[0].publishers tests', () => {
   it('Valid - properties[0].publishers is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].publishers');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -17,7 +17,7 @@ describe('properties[0].publishers tests', () => {
 
   it('Valid - properties[0].publishers can be empty array', () => {
     const valid = stubSrFullModified('properties[0].publishers', () => []);
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -25,7 +25,7 @@ describe('properties[0].publishers tests', () => {
 
   it('Invalid - properties must be array', () => {
     const invalid = stubSrFullModified('properties[0].publishers', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/properties/0/publishers');

--- a/src/ts/tests/properties/property/test.spec.ts
+++ b/src/ts/tests/properties/property/test.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-statements */
 import validListing from 'examples/swissrets-full.json';
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
@@ -9,7 +9,7 @@ import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 describe('properties[0] tests', () => {
   it('Invalid - properties[0] must be object', () => {
     const invalid = stubSrFullModified('properties[0]', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/properties/0');
@@ -18,7 +18,7 @@ describe('properties[0] tests', () => {
   it('Invalid - properties[0] must not have additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.properties![0], { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/properties/0');
@@ -27,7 +27,7 @@ describe('properties[0] tests', () => {
   it('Invalid - properties[0].id must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].id');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'id'");
     expect(output[0].instancePath).toBe('/properties/0');
@@ -35,7 +35,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].id must be string', () => {
     const invalid = stubSrFullModified('properties[0].id', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/id');
@@ -44,7 +44,7 @@ describe('properties[0] tests', () => {
   it('Invalid - properties[0].type must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].type');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'type'");
     expect(output[0].instancePath).toBe('/properties/0');
@@ -52,7 +52,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].type must be string', () => {
     const invalid = stubSrFullModified('properties[0].type', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/type');
@@ -61,7 +61,7 @@ describe('properties[0] tests', () => {
   it('Invalid - properties[0].referenceId must be present', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].referenceId');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe("must have required property 'referenceId'");
     expect(output[0].instancePath).toBe('/properties/0');
@@ -69,7 +69,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].referenceId must be string', () => {
     const invalid = stubSrFullModified('properties[0].referenceId', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/referenceId');
@@ -77,7 +77,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].unitReferenceId must be string', () => {
     const invalid = stubSrFullModified('properties[0].unitReferenceId', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/unitReferenceId');
@@ -85,7 +85,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].unitReferenceId if valid, must have corresponding unit', () => {
     const invalid = stubSrFullModified('properties[0].unitReferenceId', () => '4444');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must pass "sameAs" keyword validation');
     expect(output[0].instancePath).toBe('/properties/0/unitReferenceId');
@@ -94,7 +94,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].unitReferenceId is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].unitReferenceId');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -102,7 +102,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].visualReferenceId must be string', () => {
     const invalid = stubSrFullModified('properties[0].visualReferenceId', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/visualReferenceId');
@@ -111,7 +111,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].visualReferenceId is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].visualReferenceId');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -120,7 +120,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].utilizations is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].utilizations');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -128,7 +128,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].utilizations must be array', () => {
     const invalid = stubSrFullModified('properties[0].utilizations', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/properties/0/utilizations');
@@ -137,7 +137,7 @@ describe('properties[0] tests', () => {
   it('Invalid - properties[0].utilizations must not have duplicate items', () => {
     const invalid = stubSrFullModified('properties[0].utilizations[0]', () => 'agricultural');
     _.update(invalid, 'properties[0].utilizations[1]', () => 'agricultural');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe(
       'must NOT have duplicate items (items ## 1 and 0 are identical)'
@@ -147,7 +147,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].utilizations[0] must be string', () => {
     const invalid = stubSrFullModified('properties[0].utilizations[0]', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/utilizations/0');
@@ -155,7 +155,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].utilizations[0] must be equal to one of the allowed values', () => {
     const invalid = stubSrFullModified('properties[0].utilizations[0]', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be equal to one of the allowed values');
     expect(output[0].instancePath).toBe('/properties/0/utilizations/0');
@@ -164,7 +164,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].minergieCertification is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].minergieCertification');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -172,7 +172,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].minergieCertification must be string', () => {
     const invalid = stubSrFullModified('properties[0].minergieCertification', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/minergieCertification');
@@ -180,7 +180,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].minergieCertification must be equal to one of the allowed values', () => {
     const invalid = stubSrFullModified('properties[0].minergieCertification', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be equal to one of the allowed values');
     expect(output[0].instancePath).toBe('/properties/0/minergieCertification');
@@ -189,7 +189,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].created is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].created');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -197,7 +197,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].created must be string', () => {
     const invalid = stubSrFullModified('properties[0].created', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/created');
@@ -205,7 +205,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].created must match format "date-time"', () => {
     const invalid = stubSrFullModified('properties[0].created', () => '1-1-1 99:99:99');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match format "date-time"');
     expect(output[0].instancePath).toBe('/properties/0/created');
@@ -214,7 +214,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].modified is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].modified');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -222,7 +222,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].modified must be string', () => {
     const invalid = stubSrFullModified('properties[0].modified', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/modified');
@@ -230,7 +230,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].modified must match format "date-time"', () => {
     const invalid = stubSrFullModified('properties[0].modified', () => '1-1-1 99:99:99');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must match format "date-time"');
     expect(output[0].instancePath).toBe('/properties/0/modified');
@@ -239,7 +239,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].parcelNumbers is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].parcelNumbers');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -247,7 +247,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].parcelNumbers must be string', () => {
     const invalid = stubSrFullModified('properties[0].parcelNumbers', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/parcelNumbers');
@@ -256,7 +256,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].author is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].author');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -264,7 +264,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].author must be string', () => {
     const invalid = stubSrFullModified('properties[0].author', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/author');
@@ -273,7 +273,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].buildingZones is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].buildingZones');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -281,7 +281,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].buildingZones must be string', () => {
     const invalid = stubSrFullModified('properties[0].buildingZones', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/buildingZones');
@@ -290,7 +290,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].development is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].development');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -298,7 +298,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].development must be string', () => {
     const invalid = stubSrFullModified('properties[0].development', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/development');
@@ -306,7 +306,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].development must be equal to one of the allowed values', () => {
     const invalid = stubSrFullModified('properties[0].development', () => 'invalid');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be equal to one of the allowed values');
     expect(output[0].instancePath).toBe('/properties/0/development');
@@ -314,7 +314,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].externalReference must be object', () => {
     const invalid = stubSrFullModified('properties[0].externalReference', () => []);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be object');
     expect(output[0].instancePath).toBe('/properties/0/externalReference');
@@ -323,7 +323,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].externalReference is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].externalReference');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -332,7 +332,7 @@ describe('properties[0] tests', () => {
   it('Invalid - properties[0].externalReference must not have additional properties', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.assign(invalid.properties![0].externalReference, { additionalProperty: 'dummy' });
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must NOT have additional properties');
     expect(output[0].instancePath).toBe('/properties/0/externalReference');
@@ -341,7 +341,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].externalReference.refProperty is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].refProperty');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -349,7 +349,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].externalReference.refProperty must be string', () => {
     const invalid = stubSrFullModified('properties[0].externalReference.refProperty', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/externalReference/refProperty');
@@ -358,7 +358,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].externalReference.refHouse is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].refHouse');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -366,7 +366,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].externalReference.refHouse must be string', () => {
     const invalid = stubSrFullModified('properties[0].externalReference.refHouse', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/externalReference/refHouse');
@@ -375,7 +375,7 @@ describe('properties[0] tests', () => {
   it('Valid - properties[0].externalReference.refObject is optional', () => {
     const invalid = _.cloneDeep(validListing) as SwissRetsInventory;
     _.unset(invalid, 'properties[0].refObject');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -383,7 +383,7 @@ describe('properties[0] tests', () => {
 
   it('Invalid - properties[0].externalReference.refObject must be string', () => {
     const invalid = stubSrFullModified('properties[0].externalReference.refObject', () => 33);
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be string');
     expect(output[0].instancePath).toBe('/properties/0/externalReference/refObject');
@@ -394,7 +394,7 @@ describe('properties[0] tests', () => {
       'properties[0].localizations[0].attachments.documents[0].url',
       () => 'http://www.wohnträum.li/tour/gHHJ?ref=text£ä.w'
     );
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -405,7 +405,7 @@ describe('properties[0] tests', () => {
       'properties[0].localizations[0].attachments.youTubeLinks[0].url',
       () => 'http://www.wohnträum.li/tour/gHHJ?ref=text£ä.w'
     );
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -413,7 +413,7 @@ describe('properties[0] tests', () => {
 
   it('Valid - properties[0].seller.inquiryEmail is valid', () => {
     const valid = stubSrFullModified('properties[0].seller.inquiryEmail', () => 'test@email.com');
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
@@ -421,7 +421,7 @@ describe('properties[0] tests', () => {
 
   it('invalid - properties[0].seller.inquiryEmail is not valid', () => {
     const invalid = stubSrFullModified('properties[0].seller.inquiryEmail', () => 'test1234');
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(1);

--- a/src/ts/tests/properties/test.spec.ts
+++ b/src/ts/tests/properties/test.spec.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 import { stubSrFullModified } from 'src/ts/tests/resources/swissrets-stubs';
 
 describe('properties tests', () => {
   it('Invalid - properties must be array', () => {
     const invalid = stubSrFullModified('properties', () => ({}));
-    const output = validateSwissRetsObject(invalid);
+    const output = validateSwissRets(invalid);
 
     expect(output[0].message).toBe('must be array');
     expect(output[0].instancePath).toBe('/properties');
@@ -14,7 +14,7 @@ describe('properties tests', () => {
 
   it('Valid - properties can be empty array', () => {
     const valid = stubSrFullModified('properties', () => []);
-    const output = validateSwissRetsObject(valid);
+    const output = validateSwissRets(valid);
 
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);

--- a/src/ts/tests/validator/validator.spec.ts
+++ b/src/ts/tests/validator/validator.spec.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import { SwissRetsInventory } from 'src/ts/model/swissrets-model';
-import { validateSwissRetsObject } from 'src/ts/validator/validator';
+import { validateSwissRets } from 'src/ts/validator/validator';
 
 describe('Unit Test: Validate Samples', () => {
   it('Valid - Should not return error', () => {
-    const output = validateSwissRetsObject(provideTestData('sr-valid'));
+    const output = validateSwissRets(provideTestData('sr-valid'));
     expect(output).toBeDefined();
     expect(output).toHaveLength(0);
   });
@@ -16,7 +16,7 @@ describe('Unit Test: Validate Samples', () => {
     // @ts-expect-error - we know this is valid
     delete testData.properties[0].referenceId;
 
-    const output = validateSwissRetsObject(testData);
+    const output = validateSwissRets(testData);
 
     // then
     expect(output).toHaveLength(1);
@@ -31,7 +31,7 @@ describe('Unit Test: Validate Samples', () => {
     // @ts-expect-error - we know this is valid
     testData.properties[0].foo = 'bar';
 
-    const output = validateSwissRetsObject(testData);
+    const output = validateSwissRets(testData);
 
     // then
     expect(output).toHaveLength(1);
@@ -41,7 +41,7 @@ describe('Unit Test: Validate Samples', () => {
   });
 
   it('Invalid - project.unit has same refenereceId', () => {
-    const output = validateSwissRetsObject(provideTestData('sr-invalid-uniqId'));
+    const output = validateSwissRets(provideTestData('sr-invalid-uniqId'));
 
     expect(output).toHaveLength(1);
     expect(output[0].message).toBe('must pass "uniqueId" keyword validation');
@@ -50,7 +50,7 @@ describe('Unit Test: Validate Samples', () => {
   });
 
   it('Invalid - properties.unitReferenceId is not same as project.unit.refenereceId', () => {
-    const output = validateSwissRetsObject(provideTestData('sr-invalid-sameAs'));
+    const output = validateSwissRets(provideTestData('sr-invalid-sameAs'));
 
     expect(output).toHaveLength(1);
     expect(output[0].message).toBe('must pass "sameAs" keyword validation');

--- a/src/ts/validator/validator.ts
+++ b/src/ts/validator/validator.ts
@@ -10,24 +10,26 @@ import { SwissRetsInventory } from '../model/swissrets-model';
 import { allCustomValidators } from '../validator/custom-validation';
 import { ErrorDto } from '../validator/validator-types';
 
-export const validateSwissRetsString = (swissretsJson: string): ErrorDto[] => {
+export type SwissRetsString = string;
+
+/**
+ * Validates the given SwissRETS JSON string or object against the schema.
+ * @param swissretsJson The SwissRETS JSON string or object to validate.
+ * @returns An array of errors. If the array is empty, the JSON is valid.
+ */
+export const validateSwissRets = (
+  swissretsJson: SwissRetsString | SwissRetsInventory
+): ErrorDto[] => {
   const ajv2020Instance = new Ajv2020({ allErrors: true, verbose: true });
   AjvFormats(ajv2020Instance);
 
   each(allCustomValidators(), (item: KeywordDefinition) => ajv2020Instance.addKeyword(item));
 
-  ajv2020Instance.validate(provideSchema(), JSON.parse(swissretsJson));
-
-  return (ajv2020Instance.errors as unknown as ErrorDto[]) || [];
-};
-
-export const validateSwissRetsObject = (swissretsObject: SwissRetsInventory): ErrorDto[] => {
-  const ajv2020Instance = new Ajv2020({ allErrors: true, verbose: true });
-  AjvFormats(ajv2020Instance);
-
-  each(allCustomValidators(), (item: KeywordDefinition) => ajv2020Instance.addKeyword(item));
-
-  ajv2020Instance.validate(provideSchema(), swissretsObject);
+  if (swissretsJson instanceof Object) {
+    ajv2020Instance.validate(provideSchema(), swissretsJson);
+  } else {
+    ajv2020Instance.validate(provideSchema(), JSON.parse(swissretsJson as SwissRetsString));
+  }
 
   return (ajv2020Instance.errors as unknown as ErrorDto[]) || [];
 };


### PR DESCRIPTION
This pull request includes changes to simplify the validation process by consolidating validation methods and updating test cases accordingly. The most important changes include the replacement of specific validation methods with a unified `validateSwissRets` method across various files.

### Consolidation of Validation Methods:

* [`src/ts/validator/validator.ts`](diffhunk://#diff-49dc1590a066e79a554c9850f88be05ec1b2975b839f2343ba44dea6fa3ab1beR13-R22): Unified `validateSwissRetsString` and `validateSwissRetsObject` to `validateSwissRets` function.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20): Updated import statements and example usage to replace `validateSwissRetsString` and `validateSwissRetsObject` with `validateSwissRets`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R33) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R46)

* [`src/ts/index.ts`](diffhunk://#diff-fbc70145ad475990ac05347a804a734e94748579176e9aa4208d3ea7d90f015aL2-R5): Modified exports to use `validateSwissRets` for both string and object validations.
