### PR TITLE
feat: add SwissRetsVersion enum and version consistency tests

### DIFF
--- a/src/ts/model/swissrets-version.ts
+++ b/src/ts/model/swissrets-version.ts
@@ -1,0 +1,3 @@
+export enum SwissRetsVersion {
+  current = '3.0'
+}

--- a/src/ts/tests/ensure-version-consistency.spec.ts
+++ b/src/ts/tests/ensure-version-consistency.spec.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+import { SwissRetsInventory } from '../model/swissrets-model';
+import { SwissRetsVersion } from '../model/swissrets-version';
+
+describe('sample files should match SwissRetsVersion.current', () => {
+  it.each(['sr-valid-full', 'sr-valid-min', 'sr-invalid-uniqId', 'sr-invalid-sameAs'])(
+    'Valid - sr-valid',
+    (file: string) => {
+      const testdata = provideTestData(file);
+      expect(testdata.generator.version).toEqual(SwissRetsVersion.current);
+    }
+  );
+
+  it('Valid - package.json version should match SwissRetsVersion.current', () => {
+    const packagefile = fs
+      .readFileSync(path.resolve(__dirname, `../../../package.json`))
+      .toString();
+    const testdata = JSON.parse(packagefile);
+    expect(testdata.version.indexOf(SwissRetsVersion.current)).toEqual(0);
+  });
+});
+
+const provideTestData = (file: string): SwissRetsInventory => {
+  let sampleFile: string;
+  switch (file) {
+    case 'sr-valid-full':
+      sampleFile = path.resolve(__dirname, `../../../examples/swissrets-full.json`);
+      break;
+    case 'sr-valid-min':
+      sampleFile = path.resolve(__dirname, `../../../examples/swissrets-min.json`);
+      break;
+    case 'sr-invalid-uniqId':
+      sampleFile = path.resolve(__dirname, `./resources/sr-invalid-uniqId.json`);
+      break;
+    case 'sr-invalid-sameAs':
+      sampleFile = path.resolve(__dirname, `./resources/sr-invalid-sameAs.json`);
+      break;
+    default:
+      throw new Error(`Invalid test data file: ${file}`);
+  }
+  const sample = fs.readFileSync(sampleFile).toString();
+  return JSON.parse(sample) as SwissRetsInventory;
+};

--- a/src/ts/tests/resources/sr-invalid-sameAs.json
+++ b/src/ts/tests/resources/sr-invalid-sameAs.json
@@ -2,7 +2,7 @@
   "created": "2023-03-23T08:11:12Z",
   "generator": {
     "name": "CASAGATEWAY",
-    "version": "2.5"
+    "version": "3.0"
   },
   "properties": [
     {

--- a/src/ts/tests/resources/sr-invalid-uniqId.json
+++ b/src/ts/tests/resources/sr-invalid-uniqId.json
@@ -2,7 +2,7 @@
   "created": "2023-03-23T08:11:12Z",
   "generator": {
     "name": "CASAGATEWAY",
-    "version": "2.5"
+    "version": "3.0"
   },
   "properties": [
     {

--- a/src/ts/tests/validator/validator.spec.ts
+++ b/src/ts/tests/validator/validator.spec.ts
@@ -40,6 +40,20 @@ describe('Unit Test: Validate Samples', () => {
     expect(output[0].instancePath).toBe('/properties/0');
   });
 
+  it('Valid - remove additional property', () => {
+    // when
+    const testData = provideTestData('sr-valid');
+    // @ts-expect-error - we know this is valid
+    testData.properties[0].foo = 'bar';
+
+    const output = validateSwissRets(testData, { removeAdditional: true });
+
+    // then
+    expect(output).toHaveLength(0);
+    // @ts-expect-error - we know this is valid
+    expect(testData.properties[0].foo).toBeUndefined();
+  });
+
   it('Invalid - project.unit has same refenereceId', () => {
     const output = validateSwissRets(provideTestData('sr-invalid-uniqId'));
 

--- a/src/ts/validator/validator.ts
+++ b/src/ts/validator/validator.ts
@@ -12,24 +12,32 @@ import { ErrorDto } from '../validator/validator-types';
 
 export type SwissRetsString = string;
 
+export interface validatorConfig {
+  /**
+   * If true, additional properties will be removed from the object before validation.
+   * If false, additional properties will cause validation to fail.
+   */
+  removeAdditional: boolean;
+}
+
 /**
  * Validates the given SwissRETS JSON string or object against the schema.
  * @param swissretsJson The SwissRETS JSON string or object to validate.
  * @returns An array of errors. If the array is empty, the JSON is valid.
  */
 export const validateSwissRets = (
-  swissretsJson: SwissRetsString | SwissRetsInventory
+  swissretsJson: SwissRetsString | SwissRetsInventory,
+  config: validatorConfig = { removeAdditional: false }
 ): ErrorDto[] => {
-  const ajv2020Instance = new Ajv2020({ allErrors: true, verbose: true });
+  const ajv2020Instance = new Ajv2020({ allErrors: true, verbose: true, ...config });
   AjvFormats(ajv2020Instance);
 
   each(allCustomValidators(), (item: KeywordDefinition) => ajv2020Instance.addKeyword(item));
 
-  if (swissretsJson instanceof Object) {
-    ajv2020Instance.validate(provideSchema(), swissretsJson);
-  } else {
-    ajv2020Instance.validate(provideSchema(), JSON.parse(swissretsJson as SwissRetsString));
-  }
+  const jsonObject: SwissRetsInventory =
+    swissretsJson instanceof Object ? swissretsJson : JSON.parse(swissretsJson);
+
+  ajv2020Instance.validate(provideSchema(), jsonObject);
 
   return (ajv2020Instance.errors as unknown as ErrorDto[]) || [];
 };


### PR DESCRIPTION
This pull request includes changes to introduce a new version enum, ensure version consistency across various files, and add a new validation configuration. The most important changes include the creation of a new enum for the SwissRets version, updates to test files to match the new version, and enhancements to the validation logic.

### Introduction of a new version enum:

* [`src/ts/model/swissrets-version.ts`](diffhunk://#diff-d43b63effff3e073bbc0ea5e6b1452ebc0c8d773a852e52938b05d75daa68b64R1-R3): Added a new enum `SwissRetsVersion` to define the current version as '3.0'.

### Updates to test files for version consistency:

* [`src/ts/tests/ensure-version-consistency.spec.ts`](diffhunk://#diff-314fdb97ac918077f8937058f5543c5db27628a0e907c3d753cfbe55af5d2c4fR1-R44): Added tests to ensure that sample files and `package.json` match the current `SwissRetsVersion`.
* `src/ts/tests/resources/sr-invalid-sameAs.json` and `src/ts/tests/resources/sr-invalid-uniqId.json`: Updated the version in the test data files to '3.0'. [[1]](diffhunk://#diff-1c0d15d280cf2fefc8f9d5673fb24dd80e9e1261c28eadc2b848a36ef10fdaefL5-R5) [[2]](diffhunk://#diff-11080e5b2171bdfa7e7752f9eeedfe2d487e36600c31851b313af8ac6bb02b1dL5-R5)

### Enhancements to validation logic:

* [`src/ts/validator/validator.ts`](diffhunk://#diff-49dc1590a066e79a554c9850f88be05ec1b2975b839f2343ba44dea6fa3ab1beR15-R40): Added a new interface `validatorConfig` to allow removal of additional properties before validation and updated the `validateSwissRets` function to use this configuration.
* [`src/ts/tests/validator/validator.spec.ts`](diffhunk://#diff-01d55bc19e2de3a3f7f0deff6d8805337ec6b53ef01da944361c6f768ddbc766R43-R56): Added a unit test to validate the removal of additional properties when the `removeAdditional` configuration is set to true.