### PR TITLE
fix: export swissrets-version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualipool/swissrets-json",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualipool/swissrets-json",
-      "version": "3.0.0-alpha.4",
+      "version": "3.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualipool/swissrets-json",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "description": "A swiss real estate transfer standard.",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,4 +1,5 @@
 export * from './model/swissrets-model';
+export * from './model/swissrets-version';
 export { validateSwissRets } from './validator/validator';
 export * from './validator/validator-types';
 // eslint-disable-next-line prettier/prettier


### PR DESCRIPTION
This pull request includes updates to the package version and exports in the TypeScript index file.

Exports update:

* [`src/ts/index.ts`](diffhunk://#diff-fbc70145ad475990ac05347a804a734e94748579176e9aa4208d3ea7d90f015aR2): Added export for `swissrets-version` from the `model` directory.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `3.0.0-alpha.4` to `3.0.0-alpha.5`.