### PR TITLE
feat/rename to SwissretsVersion.latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualipool/swissrets-json",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualipool/swissrets-json",
-      "version": "3.0.0-alpha.5",
+      "version": "3.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualipool/swissrets-json",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "description": "A swiss real estate transfer standard.",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/src/ts/model/swissrets-version.ts
+++ b/src/ts/model/swissrets-version.ts
@@ -1,3 +1,3 @@
 export enum SwissRetsVersion {
-  current = '3.0'
+  latest = '3.0'
 }

--- a/src/ts/tests/ensure-version-consistency.spec.ts
+++ b/src/ts/tests/ensure-version-consistency.spec.ts
@@ -8,7 +8,7 @@ describe('sample files should match SwissRetsVersion.current', () => {
     'Valid - sr-valid',
     (file: string) => {
       const testdata = provideTestData(file);
-      expect(testdata.generator.version).toEqual(SwissRetsVersion.current);
+      expect(testdata.generator.version).toEqual(SwissRetsVersion.latest);
     }
   );
 
@@ -17,7 +17,7 @@ describe('sample files should match SwissRetsVersion.current', () => {
       .readFileSync(path.resolve(__dirname, `../../../package.json`))
       .toString();
     const testdata = JSON.parse(packagefile);
-    expect(testdata.version.indexOf(SwissRetsVersion.current)).toEqual(0);
+    expect(testdata.version.indexOf(SwissRetsVersion.latest)).toEqual(0);
   });
 });
 


### PR DESCRIPTION
This pull request includes updates to the versioning system and corresponding test cases in the `@qualipool/swissrets-json` package. The most important changes are the version bump in `package.json` and the renaming of the `SwissRetsVersion` enum value from `current` to `latest`.

Versioning updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `3.0.0-alpha.5` to `3.0.0-alpha.6`.

Enum updates:

* [`src/ts/model/swissrets-version.ts`](diffhunk://#diff-d43b63effff3e073bbc0ea5e6b1452ebc0c8d773a852e52938b05d75daa68b64L2-R2): Renamed the `SwissRetsVersion` enum value from `current` to `latest`.

Test updates:

* [`src/ts/tests/ensure-version-consistency.spec.ts`](diffhunk://#diff-314fdb97ac918077f8937058f5543c5db27628a0e907c3d753cfbe55af5d2c4fL11-R11): Updated test cases to reflect the renaming of the `SwissRetsVersion` enum value from `current` to `latest`. [[1]](diffhunk://#diff-314fdb97ac918077f8937058f5543c5db27628a0e907c3d753cfbe55af5d2c4fL11-R11) [[2]](diffhunk://#diff-314fdb97ac918077f8937058f5543c5db27628a0e907c3d753cfbe55af5d2c4fL20-R20)