### PR TITLE
chore: udate contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,7 @@ Thank you for contributing to SwissRETS
 1. A maintainer will then take care about merging the pull request.
 
 ## Release process (maintainer only)
-1. Increase the version number according to [semver](http://semver.org/) using `npm version patch|preminor|minor|premajor|major [--preid alpha|beta]`.
-1. Create a (pre-)release in Github with matching version number in the release name. A new Github package will automatically be created for the given release.
+1. Execute the ['Release' action](https://github.com/qualipool/swissrets-json/actions/workflows/release.yaml). A Github (pre-)release and [npm package](https://www.npmjs.com/package/@qualipool/swissrets-json) will automatically be created by the process.
 
 ## Developing - before you start
 


### PR DESCRIPTION
This pull request updates the release process in the `CONTRIBUTING.md` file to streamline the creation of GitHub releases and npm packages.

Changes to release process:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L33-R33): Updated the release process to use the 'Release' action workflow, which automates the creation of GitHub (pre-)releases and npm packages.