### PR TITLE
chore: switch to trusted NPM publishing (OIDC-based)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build the package
         run: npm run build
       - name: Copy documentation to the dist folder
-        run: mkdir dist/docs & cp -a docs/. dist/docs
+        run: mkdir -p dist/docs && cp -a docs/. dist/docs
       - name: Publish the package
         run: npm publish --provenance --access=public
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
       packages: write
       pull-requests: write
       checks: write
+      id-token: write
     steps:
       - name: Get releaser app token
         id: releaser-app-token
@@ -80,9 +81,7 @@ jobs:
       - name: Copy documentation to the dist folder
         run: mkdir dist/docs & cp -a docs/. dist/docs
       - name: Publish the package
-        run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access=public
 
       ######
       ## Create GitHub release and release notes


### PR DESCRIPTION
## Pull request overview

Switches the release workflow from token-based npm publishing to OIDC-based trusted publishing with provenance, aligning releases with npm’s “trusted publishing” flow from GitHub Actions.

**Changes:**
- Grant `id-token: write` permission to enable OIDC token minting in the workflow.
- Publish to npm using `npm publish --provenance` (removing `NODE_AUTH_TOKEN` usage).